### PR TITLE
Move the downward API directory to '/etc/podnetinfo'

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ I0710 08:07:16.903669       1 app_sample.go:27] netlib.GetEnv Response:
 | KUBERNETES_SERVICE_PORT_HTTPS|: 443
 | KUBERNETES_PORT          |: tcp://10.96.0.1:443
 | KUBERNETES_PORT_443_TCP_ADDR|: 10.96.0.1
-I0710 08:07:16.903756       1 network.go:18] getting network status from path: /etc/podinfo/annotations
+I0710 08:07:16.903756       1 network.go:18] getting network status from path: /etc/podnetinfo/annotations
 I0710 08:07:16.904215       1 app_sample.go:36] netlib.GetNetworkStatus Response:
 | 0                        |: &{Name: Interface: IPs:[10.96.1.157] Mac:}
 ...

--- a/lib/v1alpha/network.go
+++ b/lib/v1alpha/network.go
@@ -28,8 +28,8 @@ import (
 
 
 const (
-	filePathAnnotation = "/etc/podinfo/annotations"
-	filePathLabel = "/etc/podinfo/labels"
+	filePathAnnotation = "/etc/podnetinfo/annotations"
+	filePathLabel = "/etc/podnetinfo/labels"
 )
 
 //

--- a/samples/c_app/README.md
+++ b/samples/c_app/README.md
@@ -46,10 +46,10 @@ $ ./bin/c_sample
 If the application is not actually running in a container where annotations have been
 exposed, run the following to copy a sample annotation file onto the system. There are
 a couple of examples, so choose one that suits your testing. Make sure to name the
-file 'annotations' in the '/etc/podinfo/' directory.
+file 'annotations' in the '/etc/podnetinfo/' directory.
 ```
-$ sudo mkdir -p /etc/podinfo/
-$ sudo cp samples/annotations/annotations_all /etc/podinfo/annotations
+$ sudo mkdir -p /etc/podnetinfo/
+$ sudo cp samples/annotations/annotations_all /etc/podnetinfo/annotations
 ```
 
 SR-IOV exposes the PCI Addresses of the VF to the container using an

--- a/samples/dpdk_app/sriov/sriov-pod-1.yaml
+++ b/samples/dpdk_app/sriov/sriov-pod-1.yaml
@@ -12,8 +12,8 @@ spec:
     securityContext:
       privileged: true
     volumeMounts:
-    - mountPath: /etc/podinfo
-      name: podinfo
+    - mountPath: /etc/podnetinfo
+      name: podnetinfo
       readOnly: false
     - mountPath: /dev/hugepages
       name: hugepage
@@ -39,7 +39,7 @@ spec:
     # DPDK command line options.
     #command: ["sleep", "infinity"]
   volumes:
-  - name: podinfo
+  - name: podnetinfo
     downwardAPI:
       items:
         - path: "labels"

--- a/samples/go_app/README.md
+++ b/samples/go_app/README.md
@@ -45,10 +45,10 @@ Valid log levels are:
 If the application is not actually running in a container where annotations have been
 exposed, run the following to copy a sample annotation file onto the system. There are
 a couple of examples, so choose one that suits your testing. Make sure to name the
-file 'annotations' in the '/etc/podinfo/' directory.
+file 'annotations' in the '/etc/podnetinfo/' directory.
 ```
-$ sudo mkdir -p /etc/podinfo/
-$ sudo cp samples/annotations/annotations_all /etc/podinfo/annotations
+$ sudo mkdir -p /etc/podnetinfo/
+$ sudo cp samples/annotations/annotations_all /etc/podnetinfo/annotations
 ```
 
 SR-IOV exposes the PCI Addresses of the VF to the container using an

--- a/samples/testpod/pod.yaml
+++ b/samples/testpod/pod.yaml
@@ -8,10 +8,10 @@ spec:
     image: app-netutil
     imagePullPolicy: IfNotPresent
     volumeMounts:
-      - name: podinfo
-        mountPath: /etc/podinfo
+      - name: podnetinfo
+        mountPath: /etc/podnetinfo
   volumes:
-    - name: podinfo
+    - name: podnetinfo
       downwardAPI:
         items:
           - path: "annotations"


### PR DESCRIPTION
Move the downward API directory to '/etc/podnetinfo' to match SR-IOV admission controller value.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>