### PR TITLE
Add hugepage Downward API support.

### DIFF
--- a/c_api/netutil_c_api.go
+++ b/c_api/netutil_c_api.go
@@ -10,6 +10,11 @@ struct CPUResponse {
     char*    CPUSet;
 };
 
+struct HugepagesResponse {
+    int64_t  Request;
+    int64_t  Limit;
+};
+
 #define NETUTIL_ERRNO_SUCCESS 0
 #define NETUTIL_ERRNO_FAIL 1
 #define NETUTIL_ERRNO_SIZE_ERROR 2
@@ -101,7 +106,6 @@ struct InterfaceResponse {
 	struct InterfaceData *pIface;
 };
 
-
 */
 import "C"
 import "unsafe"
@@ -143,6 +147,20 @@ func GetCPUInfo(c_cpuResp *C.struct_CPUResponse) int64 {
 		return NETUTIL_ERRNO_SUCCESS
 	}
 	glog.Errorf("netlib.GetCPUInfo() err: %+v", err)
+	return NETUTIL_ERRNO_FAIL
+}
+
+//export GetHugepages
+func GetHugepages(c_hugepagesResp *C.struct_HugepagesResponse) int64 {
+	flag.Parse()
+	hugepagesRsp, err := netlib.GetHugepages()
+
+	if err == nil {
+		c_hugepagesResp.Request = C.long(hugepagesRsp.Request)
+		c_hugepagesResp.Limit = C.long(hugepagesRsp.Limit)
+		return NETUTIL_ERRNO_SUCCESS
+	}
+	glog.Errorf("netlib.GetHugepages() err: %+v", err)
 	return NETUTIL_ERRNO_FAIL
 }
 

--- a/lib/v1alpha/hugepages.go
+++ b/lib/v1alpha/hugepages.go
@@ -1,0 +1,54 @@
+package apputil
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"strconv"
+
+	"github.com/golang/glog"
+
+	"github.com/openshift/app-netutil/pkg/types"
+)
+
+//
+// API Functions
+//
+func GetHugepages() (*types.HugepagesResponse, error) {
+	var request int64
+	var limit int64
+
+	reqPath := filepath.Join(types.DownwardAPIMountPath, types.HugepagesRequestPath)
+	glog.Infof("GetHugepages: Open %s", reqPath)
+	requestStr, reqErr := ioutil.ReadFile(reqPath)
+	if reqErr != nil {
+		glog.Infof("Error getting %s info: %v", reqPath, reqErr)
+		request = 0
+	} else {
+		request, reqErr = strconv.ParseInt(string(bytes.TrimSpace(requestStr)), 10, 64)
+		if reqErr != nil {
+			glog.Infof("Error converting limit \"%s\": %v", requestStr, reqErr)
+		}
+	}
+
+	limPath := filepath.Join(types.DownwardAPIMountPath, types.HugepagesLimitPath)
+	glog.Infof("GetHugepages: Open %s", limPath)
+	limitStr, limErr := ioutil.ReadFile(limPath)
+	if limErr != nil {
+		glog.Infof("Error getting %s info: %v", limPath, limErr)
+		limit = 0
+	} else {
+		limit, limErr = strconv.ParseInt(string(bytes.TrimSpace(limitStr)), 10, 64)
+		if limErr != nil {
+			glog.Infof("Error converting limit \"%s\": %v", limitStr, limErr)
+		}
+	}
+
+	if reqErr != nil && limErr != nil {
+		return nil, reqErr
+	}
+	return &types.HugepagesResponse{
+		Request: request,
+		Limit:   limit,
+	}, nil
+}

--- a/lib/v1alpha/network.go
+++ b/lib/v1alpha/network.go
@@ -17,6 +17,7 @@ package apputil
 import (
 	"bufio"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/golang/glog"
@@ -25,10 +26,6 @@ import (
 	"github.com/openshift/app-netutil/pkg/networkstatus"
 	"github.com/openshift/app-netutil/pkg/types"
 	"github.com/openshift/app-netutil/pkg/userspace"
-)
-
-const (
-	filePathAnnotation = "/etc/podnetinfo/annotations"
 )
 
 //
@@ -44,10 +41,7 @@ func GetInterfaces() (*types.InterfaceResponse, error) {
 	response := &types.InterfaceResponse{}
 
 	// Open Annotations File
-	annotationPath := ""
-	if annotationPath == "" {
-		annotationPath = filePathAnnotation
-	}
+	annotationPath := filepath.Join(types.DownwardAPIMountPath, types.AnnotationsPath)
 	glog.Infof("GetInterfaces: Open %s", annotationPath)
 	file, err := os.Open(annotationPath)
 	if err != nil {
@@ -165,7 +159,7 @@ func GetInterfaces() (*types.InterfaceResponse, error) {
 			// If there are more "unknown" interface types than there are
 			// PCI interfaces not in the list, then mark the "default"
 			// interface as a host interface.
-			if ifaceData.NetworkStatus.Default && unknownCnt > len(pciAddressSlice){
+			if ifaceData.NetworkStatus.Default && unknownCnt > len(pciAddressSlice) {
 				ifaceData.DeviceType = types.INTERFACE_TYPE_HOST
 				unknownCnt--
 				glog.Infof("%s is the \"default\" interface, mark as \"%s\"",

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -15,6 +15,11 @@ type CPUResponse struct {
 	CPUSet string `json:"cpuset,omitempty"`
 }
 
+type HugepagesResponse struct {
+	Request int64
+	Limit   int64
+}
+
 type InterfaceResponse struct {
 	Interface []*InterfaceData
 }
@@ -28,3 +33,12 @@ type InterfaceData struct {
 	DeviceType    string                 `json:"device-type,omitempty"`
 	NetworkStatus nettypes.NetworkStatus `json:"network-status,omitempty"`
 }
+
+// Temporary - Use from network-resources-injector once PR merged.
+const (
+	DownwardAPIMountPath = "/etc/podnetinfo"
+	AnnotationsPath      = "annotations"
+	LabelsPath           = "labels"
+	HugepagesRequestPath = "hugepages_request"
+	HugepagesLimitPath   = "hugepages_limit"
+)

--- a/samples/c_app/README.md
+++ b/samples/c_app/README.md
@@ -20,46 +20,44 @@ This builds the GO library as a `.so` file and a C header file under the `bin/`
 directory. The sample C application then includes the C header file and the
 application binary called `c_sample` is built under `bin/` directory.
 
-### Set LD_LIBRARY_PATH
-Before testing, the application needs to know where the shared library is located.
-Either copy the `.so` file to a common location (i.e. `/usr/lib/`) or set
-`LD_LIBRARY_PATH`:
-```
-$ echo $LD_LIBRARY_PATH
-
-$ export LD_LIBRARY_PATH=$PWD/bin:$LD_LIBRARY_PATH
-```
-
-Note: Printed the original value of `LD_LIBRARY_PATH` so it can be reset later if
-desired. Use the following to clear out:
-```
-$ unset LD_LIBRARY_PATH
-```
-
 ### Test
+Before testing, the application needs to know where the shared library is located.
+Either copy the `.so` file to a common location (i.e. `/usr/lib/`) or pass the
+`LD_LIBRARY_PATH` environment variable via the command line.
+
 Run the application binary:
 ```
-$ ./bin/c_sample
+$ LD_LIBRARY_PATH=$PWD/bin:$LD_LIBRARY_PATH ./bin/c_sample
 ```
 
 #### Run locally
 If the application is not actually running in a container where annotations have been
 exposed, run the following to copy a sample annotation file onto the system. There are
 a couple of examples, so choose one that suits your testing. Make sure to name the
-file 'annotations' in the '/etc/podnetinfo/' directory.
+file `annotations` in the `/etc/podnetinfo/` directory.
 ```
 $ sudo mkdir -p /etc/podnetinfo/
-$ sudo cp samples/annotations/annotations_all /etc/podnetinfo/annotations
+$ sudo cp samples/annotations/annotations_deviceinfo_pci /etc/podnetinfo/annotations
 ```
 
 SR-IOV exposes the PCI Addresses of the VF to the container using an
 environmental variable. If the application is not actually running in a
-container where the SR-IOV environmental variables have been created, run
-the following to set a sample environmental variable in the session:
+container where the SR-IOV environmental variables have been created, pass
+them in through the command line. If the `annotations` file is using the
+`device-info` field in the `network-status`, then make sure the PCI values
+match.
 ```
-$ export PCIDEVICE_INTEL_COM_SRIOV=0000:03:02.1,0000:03:04.3
-$ echo $PCIDEVICE_INTEL_COM_SRIOV
-0000:03:02.1,0000:03:04.3
+$ LD_LIBRARY_PATH=$PWD/bin:$LD_LIBRARY_PATH PCIDEVICE_INTEL_COM_SRIOV=0000:01:02.5,0000:01:0a.4 ./bin/c_sample
+```
+
+#### Hugepage Requests and Limits
+To test the hugepage request and limit are being provided to a container via
+via the Downward API, the values need to be provided in the associated files.
+If the application is not actually running in a container, then the files
+can be created manually:
+```
+sudo sh -c 'echo "1024" >>/etc/podnetinfo/hugepages_request'
+sudo sh -c 'echo "1024" >>/etc/podnetinfo/hugepages_limit'
 ```
 
 ### Clean up

--- a/samples/c_app/app_sample.c
+++ b/samples/c_app/app_sample.c
@@ -252,11 +252,11 @@ static void freeInterfaces(struct InterfaceResponse *pIfaceRsp) {
 
 int main() {
 	struct CPUResponse cpuRsp;
+	struct HugepagesResponse hugepagesRsp;
 	struct InterfaceResponse ifaceRsp;
 	int err;
 
 	printf("Starting sample C application.\n");
-
 
 	//
 	// Example of a C call to GO that returns a string.
@@ -277,6 +277,17 @@ int main() {
 		free(cpuRsp.CPUSet);
 	}
 
+	//
+	// Example of a C call to GO that returns a structure.
+	//
+	printf("Call NetUtil GetHugepages():\n");
+	memset(&hugepagesRsp, 0, sizeof(hugepagesRsp));
+	err = GetHugepages(&hugepagesRsp);
+	if (err) {
+		printf("  Couldn't get Hugepage info, err code: %d\n", err);
+	} else { 
+		printf("  Request = %ld  Limit = %ld\n", hugepagesRsp.Request, hugepagesRsp.Limit);
+	}
 
 	//
 	// Example of a C call to GO that returns a structure

--- a/samples/dpdk_app/dpdk-app-centos/README.md
+++ b/samples/dpdk_app/dpdk-app-centos/README.md
@@ -1,6 +1,6 @@
 #  Docker Image: dpdk-app-centos
 This directory contains the files needed to build a DPDK based test image.
-This image is based on CentOS (latest) base image built with DPDK 19.08.
+This image is based on CentOS 7 base image built with DPDK 19.08.
 This image is intended to work with multiple CNIs that intend to tie into
 DPDK running in a container.
 
@@ -9,7 +9,7 @@ The SR-IOV Device Plugin detects and tracks the VFs associated with an
 SR-IOV PF. The SR-IOV CNI updates the VF as needed and the PCI Address
 associated with the VF is passed to the container via environmental
 variables. The container, like this one, boots up and reads the
-environmental variables (via the app-netuilt) and runs a DPDK application.
+environmental variables (via the app-netulit) and runs a DPDK application.
 
 ## Userspace CNI
 The Userspace CNI inconjunction with the OVS CNI Library (cniovs) or VPP
@@ -41,7 +41,7 @@ OR
 ## Reduce Image Size
 Multi-stage builds are a new feature requiring **Docker 17.05** or higher on
 the daemon and client. If multi-stage builds are NOT supported on your system,
-then comment out the lines between '# BEGIN' and '# END' in the Dockerfile:
+then comment out the lines between `# BEGIN` and `# END` in the Dockerfile:
 ```
 :
 
@@ -63,18 +63,18 @@ COPY --from=0 /usr/lib64/libnuma.so.1 /usr/lib64/libnuma.so.1
 # Docker Image Details
 This Docker Image is downloading DPDK (version 19.08 to get memif PMD)
 and building it. Once built, it changes into the DPDK `testpmd`
-directory (${DPDK_DIR}/app/test-pmd) and builds it. It then repeats
-for the DPDK `l2fwd` directory (${DPDK_DIR}/examples/l2fwd) and the
-the DPDK `l3fwd` directory (${DPDK_DIR}/examples/l3fwd).
+directory (`${DPDK_DIR}/app/test-pmd`) and builds it. It then repeats
+for the DPDK `l2fwd` directory (`${DPDK_DIR}/examples/l2fwd`) and the
+the DPDK `l3fwd` directory (`${DPDK_DIR}/examples/l3fwd`).
 
 `testpmd`, `l2fwd` and `l3fwd` are DPDK sample applications. `testpmd`
 and `l2fwd` performs Layer 2 switching and `l3fwd` performs Layer 3
 routing. All three applications are built with the `app-netutil` and
-copied into '/usr/bin/'. `l3fwd` is then also copied to '/usr/bin/' and
+copied into `/usr/bin/`. `l3fwd` is then also copied to `/usr/bin/` and
 renamed as `dpdk-app` (default option).
 
 Which DPDK sample application is run is controlled by an environmental
-variable (DPDK_SAMPLE_APP) set in the pod spec. If not set, the image
+variable (`DPDK_SAMPLE_APP`) set in the pod spec. If not set, the image
 defaults to using `dpdk-app`, which is mapped to `l3fwd`. See
 `sample/dpdk_app/sriov/sriov-pod-1.yaml` for an example of the environmental
 variable `DPDK_SAMPLE_APP` being used.
@@ -88,8 +88,8 @@ $ l3fwd -n 4 -l 1 --master-lcore 1 -w 0000:01:0a.6 -w 0000:01:02.1 -- -p 0x3 -P 
 ```
 
 This Docker image is tweaking this a little. Before `l3fwd` is built, the
-main.c file (contains main()) is updated using 'sed'. See
-'l3fwd_substitute.sh'.
+main.c file (contains `main()`) is updated using `sed`. See
+`l3fwd_substitute.sh`.
 
 **NOTE:** If a different version of DPDK is needed or used, this script and
 text file may need to be synchronized with the updated version. 
@@ -130,34 +130,33 @@ Run `dpdk-app` with no parameters, and it will be as if it is called
 as the container is started. It also prints out the generated parameter
 list, which include the dynamic socketfile path:
 ```
-sh-4.2# dpdk-app 
+sh-4.2# dpdk-app
 ENTER dpdk-app:
  argc=1
  dpdk-app
   cpuRsp.CPUSet = 0-63
+  Hugepage: Request = 2048 Limit = 2048  Using = 1024
   Interface[0]:
-    IfName="eth0"  Name="cbr0"  Type=unknown
-    MAC="ce:21:40:2a:02:9e"  IP="10.244.0.46"
+    DeviceType=host  Interface="eth0"
+    MAC="66:34:b2:6b:84:e0"  IP="10.244.0.52"
   Interface[1]:
-    IfName="net1"  Name="sriov-network-a"  Type=SR-IOV
-    MAC=""
-    PCIAddress=0000:01:0a.6
+    DeviceType=SR-IOV  Name="default/sriov-net-a"  Interface="net1"
+    Type=PCI  PCIAddress=0000:01:0a.1
   Interface[2]:
-    IfName="net2"  Name="sriov-network-b"  Type=SR-IOV
-    MAC=""
-    PCIAddress=0000:01:02.1
- myArgc=15
- dpdk-app -n 4 -l 1 --master-lcore 1 -w 0000:01:0a.6 -w 0000:01:02.1 -- -p 0x3 -P --config="(0,0,1),(1,0,1)" --parse-ptype
+    DeviceType=SR-IOV  Name="default/sriov-net-b"  Interface="net2"
+    Type=PCI  PCIAddress=0000:01:02.2
+ myArgc=17
+ dpdk-app -m 1024 -n 4 -l 1 --master-lcore 1 -w 0000:01:0a.1 -w 0000:01:02.2 -- -p 0x3 -P --config="(0,0,1),(1,0,1)" --parse-ptype
 EAL: Detected 64 lcore(s)
 EAL: Detected 2 NUMA nodes
 EAL: Multi-process socket /var/run/dpdk/rte/mp_socket
 :
 ```
 
-Then 'CTRL-C' to exit and re-run `dpdk-app` with input parameters
+Then `\<CTRL-C\>` to exit and re-run `dpdk-app` with input parameters
 modified as needed:
 ```
-dpdk-app -n 4 -l 11-13 --master-lcore 11 -w 0000:01:0a.6 -w 0000:01:02.1 -- -p 0x3 -P --config="(0,0,12),(1,0,13)" --parse-ptype
+dpdk-app -m 1024 -n 4 -l 1 --master-lcore 1 -w 0000:01:0a.1 -w 0000:01:02.2 -- -p 0x3 -P --config="(0,0,1),(1,0,1)" --parse-ptype
 ```
 
 The output from running `dpdk-app`' in the container is described here. The
@@ -174,31 +173,30 @@ ENTER dpdk-app:
 ```
 
 The next set of output come from `app-netutil` and indicate what
-data it has collected from the enviromental variables and
+data it has collected from the environment variables and
 annotations. 
 ```
   cpuRsp.CPUSet = 0-63
+  Hugepage: Request = 2048 Limit = 2048  Using = 1024
   Interface[0]:
-    IfName="eth0"  Name="cbr0"  Type=unknown
-    MAC="ce:21:40:2a:02:9e"  IP="10.244.0.46"
+    DeviceType=host  Interface="eth0"
+    MAC="66:34:b2:6b:84:e0"  IP="10.244.0.52"
   Interface[1]:
-    IfName="net1"  Name="sriov-network-a"  Type=SR-IOV
-    MAC=""
-    PCIAddress=0000:01:0a.6
+    DeviceType=SR-IOV  Name="default/sriov-net-a"  Interface="net1"
+    Type=PCI  PCIAddress=0000:01:0a.1
   Interface[2]:
-    IfName="net2"  Name="sriov-network-b"  Type=SR-IOV
-    MAC=""
-    PCIAddress=0000:01:02.1
+    DeviceType=SR-IOV  Name="default/sriov-net-b"  Interface="net2"
+    Type=PCI  PCIAddress=0000:01:02.2
 ```
 
 The next set of output indicated how `dpdk-app` is called with
 the set of parameters printed. This can be copied and rerun with
-updates as needed. But the dynamic data, such as PC Address of
+updates as needed. But the dynamic data, such as PCI Address of
 SR-IOV interfaces, or vhost socketfiles are printed and can be
 leveraged on subsequent runs.
 ```
  myArgc=15
- dpdk-app -n 4 -l 1 --master-lcore 1 -w 0000:01:0a.6 -w 0000:01:02.1 -- -p 0x3 -P --config="(0,0,1),(1,0,1)" --parse-ptype
+ dpdk-app -m 1024 -n 4 -l 1 --master-lcore 1 -w 0000:01:0a.1 -w 0000:01:02.2 -- -p 0x3 -P --config="(0,0,1),(1,0,1)" --parse-ptype
 ```
 
 The remaining output is from DPDK.

--- a/samples/dpdk_app/sriov/sriov-pod-nri-1.yaml
+++ b/samples/dpdk_app/sriov/sriov-pod-nri-1.yaml
@@ -1,3 +1,8 @@
+# Pod Spec to work with SR-IOV Network Resource Injector
+#  
+# SR-IOV Network Resource Injector is a mutating webhook that
+# adds Downward API values to the Pod Spec. So this version
+# of Pod Spec has Downward API values commented out. 
 apiVersion: v1
 kind: Pod
 metadata:
@@ -12,9 +17,9 @@ spec:
     securityContext:
       privileged: true
     volumeMounts:
-    - mountPath: /etc/podnetinfo
-      name: podnetinfo
-      readOnly: false
+    #- mountPath: /etc/podnetinfo
+    #  name: podnetinfo
+    #  readOnly: false
     - mountPath: /dev/hugepages
       name: hugepage
     resources:
@@ -43,15 +48,15 @@ spec:
     # DPDK command line options.
     #command: ["sleep", "infinity"]
   volumes:
-  - name: podnetinfo
-    downwardAPI:
-      items:
-        - path: "labels"
-          fieldRef:
-            fieldPath: metadata.labels
-        - path: "annotations"
-          fieldRef:
-            fieldPath: metadata.annotations
+  #- name: podnetinfo
+  #  downwardAPI:
+  #    items:
+  #      - path: "labels"
+  #        fieldRef:
+  #          fieldPath: metadata.labels
+  #      - path: "annotations"
+  #        fieldRef:
+  #         fieldPath: metadata.annotations
         # Exposing Hugepages via Downward API is an alpha feature in
         # Kubernetes 1.20. If K8s is greater than or equal to 1.20 and
         # and Feature Gate is enabled (FEATURE_GATES="DownwardAPIHugePages=true"),

--- a/samples/go_app/README.md
+++ b/samples/go_app/README.md
@@ -27,7 +27,7 @@ $ ./bin/go_app
 
 This application run a forever loop, calling the Network Utility Library
 and printing the results. Then sleeping for 1 minute and repeating. Use
-<CTRL>-C to exit.
+\<CTRL\>-C to exit.
 
 #### Debug Logs
 To see additional debug messages, pass logging information as input to the
@@ -45,20 +45,30 @@ Valid log levels are:
 If the application is not actually running in a container where annotations have been
 exposed, run the following to copy a sample annotation file onto the system. There are
 a couple of examples, so choose one that suits your testing. Make sure to name the
-file 'annotations' in the '/etc/podnetinfo/' directory.
+file `annotations` in the `/etc/podnetinfo/` directory.
 ```
 $ sudo mkdir -p /etc/podnetinfo/
-$ sudo cp samples/annotations/annotations_all /etc/podnetinfo/annotations
+$ sudo cp samples/annotations/annotations_deviceinfo_pci /etc/podnetinfo/annotations
 ```
 
 SR-IOV exposes the PCI Addresses of the VF to the container using an
 environmental variable. If the application is not actually running in a
-container where the SR-IOV environmental variables have been created, run
-the following to set a sample environmental variable in the session:
+container where the SR-IOV environmental variables have been created, pass
+them in through the command line. If the `annotations` file is using the
+`device-info` field in the `network-status`, then make sure the PCI values
+match.
 ```
-$ export PCIDEVICE_INTEL_COM_SRIOV=0000:03:02.1,0000:03:04.3
-$ echo $PCIDEVICE_INTEL_COM_SRIOV
-0000:03:02.1,0000:03:04.3
+$ PCIDEVICE_INTEL_COM_SRIOV=0000:01:02.5,0000:01:0a.4 ./bin/go_app -stderrthreshold=INFO
+```
+
+#### Hugepage Requests and Limits
+To test the hugepage request and limit are being provided to a container via
+via the Downward API, the values need to be provided in the associated files.
+If the application is not actually running in a container, then the files
+can be created manually:
+```
+sudo sh -c 'echo "1024" >>/etc/podnetinfo/hugepages_request'
+sudo sh -c 'echo "1024" >>/etc/podnetinfo/hugepages_limit'
 ```
 
 ### Clean up

--- a/samples/go_app/app_sample.go
+++ b/samples/go_app/app_sample.go
@@ -16,6 +16,7 @@ func main() {
 	glog.Infof("starting sample application")
 
 	for {
+		// Test GetCPUInfo()
 		glog.Infof("CALL netlib.GetCPUInfo:")
 		cpuResponse, err := netlib.GetCPUInfo()
 		if err != nil {
@@ -25,6 +26,17 @@ func main() {
 		glog.Infof("netlib.GetCPUInfo Response:")
 		fmt.Printf("| CPU     |: %+v\n", cpuResponse.CPUSet)
 
+		// Test GetHugepages()
+		glog.Infof("CALL netlib.GetHugepages:")
+		hugepagesResponse, err := netlib.GetHugepages()
+		if err != nil {
+			glog.Infof("Error calling netlib.GetHugepages: %v", err)
+		} else {
+			glog.Infof("netlib.GetHugepages Response:")
+			fmt.Printf("| HugePage|: Request=%+v  Limit=%+v\n", hugepagesResponse.Request, hugepagesResponse.Limit)
+		}
+
+		// Test GetInterfaces()
 		glog.Infof("CALL netlib.GetInterfaces:")
 		ifaceResponse, err := netlib.GetInterfaces()
 		if err != nil {


### PR DESCRIPTION
In Kubernetes 1.20, an alpha feature was added to expose the requested
hugepages to the container via the Downward API. Add a new API to check
to see if the hugepage data is passed to the container via the Downward
API, and if so, return the data to the caller.

This is feature is disabled by default in Kubernetes. If enabled when
Kubernetes is deployed via FEATURE_GATES="DownwardAPIHugePages=true",
then Downward API values can be passed to the container.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>