### PR TITLE
Add tfherbert to owners.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,7 @@ reviewers:
   - fepan
   - s1061123
   - pliurh
+  - tfherbert
 approvers:
   - zshi-redhat
   - vpickard
@@ -14,3 +15,4 @@ approvers:
   - fepan
   - s1061123
   - pliurh
+  - tfherbert


### PR DESCRIPTION
I am requesting to be added to owners so I can complete the CI/CD requirement for app-netutil.

I believe that in order to get github actions CI/CD initialized, an OWNER must enable actions.
This is why PR #25 didn't actually start a CI/CD job.

Signed-off-by: Thomas F Herbert <therbert@redhat.com>