### PR TITLE
Add git hash and version to API log

### DIFF
--- a/hack/build-c.sh
+++ b/hack/build-c.sh
@@ -12,6 +12,23 @@ export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
 export CGO_ENABLED=1
 
+GIT_COMMIT=$(git log -1 --pretty=format:%h)
+GO_COMMIT_VAR="github.com/openshift/app-netutil/lib/v1alpha.GitCommit"
+
+GIT_VERSION=$(git tag | sort -V | tail -1)
+GO_VERSION_VAR="github.com/openshift/app-netutil/lib/v1alpha.AppNetutilVersion"
+
 #go install "$@" ${REPO_PATH}/samples/go_app
-go build -o ${GOBIN}/libnetutil_api.so -buildmode=c-shared -v ${REPO_PATH}/c_api
-gcc -I${GOBIN} -L${GOBIN} -Wall -o ${GOBIN}/c_sample ${GOPATH}/src/${REPO_PATH}/samples/c_app/app_sample.c -lnetutil_api
+go build \
+  -ldflags "-X '${GO_COMMIT_VAR}=${GIT_COMMIT}' -X '${GO_VERSION_VAR}=${GIT_VERSION}'" \
+  -o ${GOBIN}/libnetutil_api.so \
+  -buildmode=c-shared \
+  -v \
+  ${REPO_PATH}/c_api
+
+gcc \
+  -I${GOBIN} \
+  -L${GOBIN} \
+  -Wall \
+  -o ${GOBIN}/c_sample \
+  ${GOPATH}/src/${REPO_PATH}/samples/c_app/app_sample.c -lnetutil_api

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -12,4 +12,13 @@ export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
 export CGO_ENABLED=0
 
-go install "$@" ${REPO_PATH}/samples/go_app
+GIT_COMMIT=$(git log -1 --pretty=format:%h)
+GO_COMMIT_VAR="github.com/openshift/app-netutil/lib/v1alpha.GitCommit"
+
+GIT_VERSION=$(git tag | sort -V | tail -1)
+GO_VERSION_VAR="github.com/openshift/app-netutil/lib/v1alpha.AppNetutilVersion"
+
+go install \
+  -ldflags "-X '${GO_COMMIT_VAR}=${GIT_COMMIT}' -X '${GO_VERSION_VAR}=${GIT_VERSION}'" \
+  "$@" \
+  ${REPO_PATH}/samples/go_app

--- a/lib/v1alpha/hugepages.go
+++ b/lib/v1alpha/hugepages.go
@@ -24,6 +24,8 @@ const (
 // API Functions
 //
 func GetHugepages() (*types.HugepagesResponse, error) {
+	glog.Infof("GetHugepages: Version=%s  Git Commit=%s\n", AppNetutilVersion, GitCommit)
+
 	response := &types.HugepagesResponse{}
 
 	// Try to retrieve this container's name from the environment variable

--- a/lib/v1alpha/network.go
+++ b/lib/v1alpha/network.go
@@ -37,7 +37,7 @@ import (
 // API Functions
 //
 func GetInterfaces() (*types.InterfaceResponse, error) {
-	glog.Infof("GetInterfaces: ENTER")
+	glog.Infof("GetInterfaces: Version=%s  Git Commit=%s\n", AppNetutilVersion, GitCommit)
 
 	response := &types.InterfaceResponse{}
 

--- a/lib/v1alpha/resource.go
+++ b/lib/v1alpha/resource.go
@@ -23,6 +23,8 @@ type EnvResponse struct {
 }
 
 func GetCPUInfo() (*types.CPUResponse, error) {
+	glog.Infof("GetCPUInfo: Version=%s  Git Commit=%s\n", AppNetutilVersion, GitCommit)
+
 	path := filepath.Join("/proc", strconv.Itoa(os.Getpid()), "root", cpusetPath)
 	glog.Infof("getting cpuset from path: %s", path)
 	cpus, err := ioutil.ReadFile(path)

--- a/lib/v1alpha/version.go
+++ b/lib/v1alpha/version.go
@@ -1,0 +1,5 @@
+package apputil
+
+// GitCommit and AppNetutilVersion overwritten by hack/build.sh and hack/build-c.sh
+var GitCommit = "v0.0.0"
+var AppNetutilVersion = "development"

--- a/pkg/networkstatus/networkstatus.go
+++ b/pkg/networkstatus/networkstatus.go
@@ -41,8 +41,6 @@ func AppendInterfaceData(netStatData *NetStatusData, ifaceRsp *types.InterfaceRe
 
 	glog.Infof("PRINT EACH NetworkStatus - len=%d", len(netStatData.networkStatusSlice))
 	for _, status := range netStatData.networkStatusSlice {
-		ifaceData = nil
-
 		glog.Infof("  status:")
 		glog.Infof("%v", status)
 


### PR DESCRIPTION
Since openshift/app-netutil is not packaged with OpenShift, there is no
way to tell what version of code is used when bugs are filed. Adding
git version and git commit hash to the logs to help determine which
version is being used.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>