### PR TITLE
Fix git version in logs

### DIFF
--- a/hack/build-c.sh
+++ b/hack/build-c.sh
@@ -15,15 +15,20 @@ export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
 export CGO_ENABLED=1
 
-GIT_COMMIT=$(git log -1 --pretty=format:%h)
 GO_COMMIT_VAR="github.com/openshift/app-netutil/lib/v1alpha.GitCommit"
+GIT_COMMIT=$(git log -1 --pretty=format:%h)
+GIT_COMMIT_STR=" -X '${GO_COMMIT_VAR}=${GIT_COMMIT}'"
 
-GIT_VERSION=$(git tag | sort -V | tail -1)
+GIT_VERSION_STR=""
 GO_VERSION_VAR="github.com/openshift/app-netutil/lib/v1alpha.AppNetutilVersion"
+GIT_TAG=`git describe --tags`
+if [ "$?" == 0 ]; then
+   GIT_VERSION_STR=" -X '${GO_VERSION_VAR}=${GIT_TAG}'"
+fi
 
 #go install "$@" ${REPO_PATH}/samples/go_app
 go build \
-  -ldflags "-X '${GO_COMMIT_VAR}=${GIT_COMMIT}' -X '${GO_VERSION_VAR}=${GIT_VERSION}'" \
+  -ldflags "${GIT_COMMIT_STR}${GIT_VERSION_STR}" \
   -o ${GOBIN}/libnetutil_api.so \
   -buildmode=c-shared \
   -v \

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -15,13 +15,18 @@ export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
 export CGO_ENABLED=0
 
-GIT_COMMIT=$(git log -1 --pretty=format:%h)
 GO_COMMIT_VAR="github.com/openshift/app-netutil/lib/v1alpha.GitCommit"
+GIT_COMMIT=$(git log -1 --pretty=format:%h)
+GIT_COMMIT_STR=" -X '${GO_COMMIT_VAR}=${GIT_COMMIT}'"
 
-GIT_VERSION=$(git tag | sort -V | tail -1)
+GIT_VERSION_STR=""
 GO_VERSION_VAR="github.com/openshift/app-netutil/lib/v1alpha.AppNetutilVersion"
+GIT_TAG=`git describe --tags`
+if [ "$?" == 0 ]; then
+   GIT_VERSION_STR=" -X '${GO_VERSION_VAR}=${GIT_TAG}'"
+fi
 
 go install \
-  -ldflags "-X '${GO_COMMIT_VAR}=${GIT_COMMIT}' -X '${GO_VERSION_VAR}=${GIT_VERSION}'" \
+  -ldflags "${GIT_COMMIT_STR}${GIT_VERSION_STR}" \
   "$@" \
   ${REPO_PATH}/samples/go_app


### PR DESCRIPTION
Original logic was always pulling the latest git tag, independant of which
commit code was based on.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>